### PR TITLE
Fix naming for helper function

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,7 +1,7 @@
 import { HttpMethod } from 'urllib';
 import { Schema } from 'mongoose';
 import { AtlasSearchIndex, AtlasSearchOptions } from './types';
-export declare const dotSeperatedObjectILabel: (obj: any) => any;
+export declare const dotSeparatedObjectILabel: (obj: any) => any;
 export declare class MongoDbAtlas {
     databaseName: string;
     options: AtlasSearchOptions;

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,10 +47,10 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.MongoDbAtlas = exports.dotSeperatedObjectILabel = void 0;
+exports.MongoDbAtlas = exports.dotSeparatedObjectILabel = void 0;
 var urllib_1 = require("urllib");
 var types_1 = require("./types");
-var dotSeperatedObjectILabel = function (obj) {
+var dotSeparatedObjectILabel = function (obj) {
     var res = {};
     (function recurse(obj, current) {
         if (current === void 0) { current = ''; }
@@ -71,7 +71,7 @@ var dotSeperatedObjectILabel = function (obj) {
     })(obj);
     return res;
 };
-exports.dotSeperatedObjectILabel = dotSeperatedObjectILabel;
+exports.dotSeparatedObjectILabel = dotSeparatedObjectILabel;
 function getAttributeTypes(schema) {
     var response = {};
     var schemaObj = schema.obj;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import {
   AtlasSearchOptions,
 } from './types';
 
-export const dotSeperatedObjectILabel = (obj: any) => {
+export const dotSeparatedObjectILabel = (obj: any) => {
   const res = {} as any;
   (function recurse(obj, current = '') {
     for (const key in obj) {


### PR DESCRIPTION
## Summary
- rename `dotSeperatedObjectILabel` to `dotSeparatedObjectILabel`
- rebuild TypeScript output

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684035b86a40832aa99decb32acb0bd9